### PR TITLE
feat: migrate buildScan to gradleEnterprise

### DIFF
--- a/finder/kotlin/build.gradle.kts
+++ b/finder/kotlin/build.gradle.kts
@@ -5,7 +5,6 @@ version = "0.0.4"
 
 plugins {
     id("kotlinx-serialization") version "1.3.40"
-    `build-scan`
     `maven-publish`
     kotlin("jvm") version "1.3.40" 
     id("org.jetbrains.dokka") version "0.9.17"
@@ -20,13 +19,6 @@ dependencies {
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
     implementation ("io.appium:java-client:2.1.0")
     testImplementation("junit:junit:4.12")
-}
-
-buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service" 
-    termsOfServiceAgree = "yes"
-
-    publishAlways() 
 }
 
 tasks.dokka {    

--- a/finder/kotlin/settings.gradle.kts
+++ b/finder/kotlin/settings.gradle.kts
@@ -14,3 +14,14 @@ pluginManagement {
         maven("https://kotlin.bintray.com/kotlinx")
     }
 }
+plugins {
+    id("com.gradle.enterprise") version("3.7.2")
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
+}


### PR DESCRIPTION
The buildScan plugin is no longer supported since Gradle 6.x

Source: https://docs.gradle.com/enterprise/gradle-plugin/