### PR TITLE
Feat/first match only

### DIFF
--- a/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
+++ b/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
@@ -21,7 +21,7 @@ public class FlutterFinder(driver: RemoteWebDriver) {
   private val driver = driver
   private val fileDetector = FileDetector({ _ -> null })
   fun ancestor(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false, firstMatchOnly: Boolean = false): FlutterElement {
-    val f = _ancestor(of, matching, matchRoot)
+    val f = _ancestor(of, matching, matchRoot, firstMatchOnly)
     f.setParent(driver)
     f.setFileDetector(fileDetector)
     return f
@@ -63,7 +63,7 @@ public class FlutterFinder(driver: RemoteWebDriver) {
     return f
   }
   fun descendant(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false, firstMatchOnly: Boolean = false): FlutterElement {
-    val f = _descendant(of, matching, matchRoot)
+    val f = _descendant(of, matching, matchRoot, firstMatchOnly)
     f.setParent(driver)
     f.setFileDetector(fileDetector)
     return f

--- a/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
+++ b/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
@@ -20,14 +20,8 @@ import pro.truongsinh.appium_flutter.finder.text as _text
 public class FlutterFinder(driver: RemoteWebDriver) {
   private val driver = driver
   private val fileDetector = FileDetector({ _ -> null })
-  fun ancestor(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false): FlutterElement {
+  fun ancestor(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false, firstMatchOnly: Boolean = false): FlutterElement {
     val f = _ancestor(of, matching, matchRoot)
-    f.setParent(driver)
-    f.setFileDetector(fileDetector)
-    return f
-  }
-  fun ancestor(of: FlutterElement, matching: FlutterElement): FlutterElement {
-    val f = _ancestor(of, matching)
     f.setParent(driver)
     f.setFileDetector(fileDetector)
     return f
@@ -68,14 +62,8 @@ public class FlutterFinder(driver: RemoteWebDriver) {
     f.setFileDetector(fileDetector)
     return f
   }
-  fun descendant(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false): FlutterElement {
+  fun descendant(of: FlutterElement, matching: FlutterElement, matchRoot: Boolean = false, firstMatchOnly: Boolean = false): FlutterElement {
     val f = _descendant(of, matching, matchRoot)
-    f.setParent(driver)
-    f.setFileDetector(fileDetector)
-    return f
-  }
-  fun descendant(of: FlutterElement, matching: FlutterElement): FlutterElement {
-    val f = _descendant(of, matching)
     f.setParent(driver)
     f.setFileDetector(fileDetector)
     return f


### PR DESCRIPTION
Currently the firstMatchOnly parameter is not passed onto flutter for ancestor and descentant finders. This PR fixes this.