### PR TITLE
Add support for setTextEntryEmulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Please replace them properly with your client.
 | [scrollIntoView](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/scrollIntoView.html) | :ok: | `driver.execute('flutter:scrollIntoView', find.byType('TextField'), {alignment: 0.1})` | Widget |
 | [scrollUntilVisible](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/scrollUntilVisible.html) | :ok: | `driver.execute('flutter:scrollUntilVisible', find.byType('ListView'), {item:find.byType('TextField'), dxScroll: 90, dyScroll: -400});` | Widget |
 | [setSemantics](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/setSemantics.html) | :x: |  | Session |
-| [setTextEntryEmulation](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/setTextEntryEmulation.html) | :x: |  | Session |
+| [setTextEntryEmulation](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/setTextEntryEmulation.html) | :ok: | `driver.execute('flutter:setTextEntryEmulation', false)` | Session |
 | [startTracing](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/startTracing.html) | :x: |  | Session |
 | [stopTracingAndDownloadTimeline](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/stopTracingAndDownloadTimeline.html) | :x: |  | Session |
 | [tap](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/tap.html) | :ok: | [`driver.elementClick(buttonFinder)`](https://github.com/truongsinh/appium-flutter-driver/blob/5df7386b59bb99008cb4cff262552c7259bb2af2/example/src/index.js#L46) | Widget |

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -48,6 +48,8 @@ export const execute = async function(
       return scrollUntilVisible(this, args[0], args[1]);
     case `scrollIntoView`:
       return scrollIntoView(this, args[0], args[1]);
+    case `setTextEntryEmulation`:
+      return setTextEntryEmulation(this, args[0]);
     case `enterText`:
       return enterText(this, args[0]);
     case `requestData`:
@@ -148,3 +150,6 @@ const setFrameSync = async (self, bool, durationMilliseconds) =>
     enabled: bool,
     timeout: durationMilliseconds * 1000,
   });
+
+const setTextEntryEmulation = async (self: FlutterDriver, enabled: boolean) =>
+  await self.socket!.executeSocketCommand({ command: `set_text_entry_emulation`, enabled });


### PR DESCRIPTION
We recently need this to support our use case. Seems to be straight forward and working well when I tested locally, but let me know if I missed something here.

Related doc: https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/setTextEntryEmulation.html

Related flutter's code: https://github.com/flutter/flutter/blob/a3fd36a11500643681f302455891b842be1fbb75/packages/flutter_driver/lib/src/common/text.dart#L63-L82