### PR TITLE
chore: update a few in example

### DIFF
--- a/driver/package.json
+++ b/driver/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@appium/schema": "^0.0.8",
-    "@appium/types": "^0.3.0",
+    "@appium/types": "^0.4.0",
     "@wdio/types": "^7.20.0",
     "json-schema": "^0.4.0",
     "tslint": "^6.1.3",

--- a/example/nodejs/src/index.js
+++ b/example/nodejs/src/index.js
@@ -7,19 +7,20 @@ const find = require('appium-flutter-finder');
 const osSpecificOps =
   process.env.APPIUM_OS === 'android'
     ? {
-        platformName: 'Android',
-        deviceName: 'Pixel 2',
+        'appium:platformName': 'Android',
+        'appium:deviceName': 'Pixel 2',
         // @todo support non-unix style path
-        app: __dirname + '/../../apps/android-real-debug.apk' // download local to run faster and save bandwith
+        'appium:app': __dirname + '/../../apps/android-real-debug.apk' // download local to run faster and save bandwith
         // app: 'https://github.com/truongsinh/appium-flutter-driver/releases/download/v0.0.4/android-real-debug.apk',
       }
     : process.env.APPIUM_OS === 'ios'
     ? {
-        platformName: 'iOS',
-        platformVersion: '12.4',
-        deviceName: 'iPhone X',
-        noReset: true,
-        app: __dirname + '/../../apps/ios-sim-debug.zip' // download local to run faster and save bandwith
+        'appium:platformName': 'iOS',
+        'appium:platformVersion': '15.5',
+        'appium:deviceName': 'iPhone 13',
+        'appium:connectionRetryTimeout': 60000,
+        'appium:noReset': true,
+        'appium:app': __dirname + '/../../apps/ios-sim-debug.zip' // download local to run faster and save bandwith
         // app: 'https://github.com/truongsinh/appium-flutter-driver/releases/download/v0.0.4/ios-sim-debug.zip',
       }
     : {};
@@ -29,7 +30,7 @@ const opts = {
   path: '/wd/hub',
   capabilities: {
     ...osSpecificOps,
-    automationName: 'Flutter'
+    'appium:automationName': 'Flutter'
   }
 };
 

--- a/example/ruby/example.rb
+++ b/example/ruby/example.rb
@@ -10,8 +10,8 @@ class ExampleTests < Minitest::Test
     caps: {
       platformName: 'iOS',
       automationName: 'flutter',
-      platformVersion: '15.0',
-      deviceName: 'iPhone 12 Pro',
+      platformVersion: '15.5',
+      deviceName: 'iPhone 13',
       app: "#{Dir.pwd}/../app/app/Runner.zip"
     },
     appium_lib: {

--- a/example/ruby/example_sample2_ios.rb
+++ b/example/ruby/example_sample2_ios.rb
@@ -10,8 +10,8 @@ class ExampleTests < Minitest::Test
     caps: {
       platformName: 'iOS',
       automationName: 'flutter',
-      platformVersion: '15.0',
-      deviceName: 'iPhone 12 Pro',
+      platformVersion: '15.5',
+      deviceName: 'iPhone 13',
       app: "#{Dir.pwd}/../sample2/iOSFullScreen.zip"
     },
     appium_lib: {


### PR DESCRIPTION
Some command raised errors like below:
hm..
```
[debug] [FlutterDriver] Executing Flutter driver command 'execute'
[debug] [FlutterDriver] >>> {"command":"get_render_tree"}
[debug] [FlutterDriver] <<< {"isError":true,"response":"Uncaught extension error while executing get_render_tree: Invalid argument(s): The source must not be null\n#0      int.parse (dart:core/runtime/libintegers_patch.dart:51:25)\n#1      new Command.deserialize (package:flutter_driver/src/common/message.dart:17:46)\n#2      new GetRenderTree.deserialize (package:flutter_driver/src/common/render_tree.dart:13:63)\n#3      new FlutterDriverExtension.<anonymous closure> (package:flutter_driver/src/extension/extension.dart:119:72)\n#4      FlutterDriverExtension.call (package:flutter_driver/src/extension/extension.dart:179:50)\n<asynchronous suspension>\n#5      BindingBase.registerServiceExtension.<anonymous closure> (package:flutter/src/foundation/binding.dart:438:32)\n<asynchronous suspension>\n#6      _runExtension (dart:developer/runtime/libdeveloper.dart:86:23)\n","type":"_extensionType","method":"ext.flutter.driver"} | previous command get_render_tree
[debug] [FlutterDriver@df52 (0b2ffcbf)] Encountered internal error running command: Error: Cannot execute command get_render_tree, server reponse {
[debug] [FlutterDriver@df52 (0b2ffcbf)]   "isError": true,
[debug] [FlutterDriver@df52 (0b2ffcbf)]   "response": "Uncaught extension error while executing get_render_tree: Invalid argument(s): The source must not be null\n#0      int.parse (dart:core/runtime/libintegers_patch.dart:51:25)\n#1      new Command.deserialize (package:flutter_driver/src/common/message.dart:17:46)\n#2      new GetRenderTree.deserialize (package:flutter_driver/src/common/render_tree.dart:13:63)\n#3      new FlutterDriverExtension.<anonymous closure> (package:flutter_driver/src/extension/extension.dart:119:72)\n#4      FlutterDriverExtension.call (package:flutter_driver/src/extension/extension.dart:179:50)\n<asynchronous suspension>\n#5      BindingBase.registerServiceExtension.<anonymous closure> (package:flutter/src/foundation/binding.dart:438:32)\n<asynchronous suspension>\n#6      _runExtension (dart:developer/runtime/libdeveloper.dart:86:23)\n",
[debug] [FlutterDriver@df52 (0b2ffcbf)]   "type": "_extensionType",
[debug] [FlutterDriver@df52 (0b2ffcbf)]   "method": "ext.flutter.driver"
[debug] [FlutterDriver@df52 (0b2ffcbf)] }
```