### PR TITLE
feat: define durationMilliseconds as ms

### DIFF
--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## not yet
+- Do not calculate `* 1000` internally for milliseconds arguments to set ms. [#319](https://github.com/appium-userland/appium-flutter-driver/issues/319)
+    - README/Examples expected the as-is
+
 ## 1.6.0
 - Update for newer Appium 2 beta
 

--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## not yet
-- Do not calculate `* 1000` internally for milliseconds arguments to set ms. [#319](https://github.com/appium-userland/appium-flutter-driver/issues/319)
-    - README/Examples expected the as-is
+- [breaking change]
+    - Do not calculate `* 1000` internally for milliseconds arguments to set ms. [#319](https://github.com/appium-userland/appium-flutter-driver/issues/319)
+        - README/Examples expected the as-is
 
 ## 1.6.0
 - Update for newer Appium 2 beta

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -170,7 +170,7 @@ const setFrameSync = async (self, bool, durationMilliseconds) =>
   await self.socket!.executeSocketCommand({
     command: `set_frame_sync`,
     enabled: bool,
-    timeout: durationMilliseconds * 1000,
+    timeout: durationMilliseconds,
   });
 
 const setTextEntryEmulation = async (self: FlutterDriver, enabled: boolean) =>

--- a/driver/lib/commands/execute/scroll.ts
+++ b/driver/lib/commands/execute/scroll.ts
@@ -34,7 +34,7 @@ export const scroll = async (
   return await self.executeElementCommand(`scroll`, elementBase64, {
     dx,
     dy,
-    duration: durationMilliseconds * 1000,
+    duration: durationMilliseconds,
     frequency,
   });
 };
@@ -60,7 +60,7 @@ export const longTap = async (
   return await self.executeElementCommand(`scroll`, elementBase64, {
     dx: 0,
     dy: 0,
-    duration: durationMilliseconds * 1000,
+    duration: durationMilliseconds,
     frequency,
   });
 };

--- a/driver/lib/commands/execute/wait.ts
+++ b/driver/lib/commands/execute/wait.ts
@@ -10,7 +10,7 @@ const waitForConstructor = (command: `waitForAbsent` | `waitFor` | `waitForTappa
 
   if (typeof durationMilliseconds === `number`) {
     args = {
-      timeout: durationMilliseconds * 1000,
+      timeout: durationMilliseconds,
     };
   } else if (typeof durationMilliseconds !== `undefined`) {
     // @todo BaseDriver's errors.InvalidArgumentError();


### PR DESCRIPTION
For https://github.com/appium-userland/appium-flutter-driver/issues/319

Not tested yet.

---


This is kind of correct `driver.execute('flutter:waitFor', buttonFinder, {durationMilliseconds: 100})` though.