### PR TITLE
Add proxy command for getWindowHandles to work with Appium 2.0 and plugins

### DIFF
--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -141,6 +141,11 @@ class FlutterDriver extends BaseDriver {
     return true;
   }
 
+  public async proxyCommand (url, method, body = null) {
+    const result = await this.proxydriver.proxyCommand(url, method, body);
+    return result
+  }
+
   public async executeCommand(cmd: string, ...args: any[]) {
     if (cmd === `receiveAsyncResponse`) {
       logger.debug(`Executing FlutterDriver response '${cmd}'`);


### PR DESCRIPTION
Fix to https://github.com/appium-userland/appium-flutter-driver/issues/424