### PR TITLE
fix: this.startNewCommandTimeout argument

### DIFF
--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -160,7 +160,7 @@ class FlutterDriver extends BaseDriver {
         // Here we manually reset the FlutterDriver CommandTimeout for commands that goe to proxy.
         this.clearNewCommandTimeout();
         const result = await this.proxydriver.executeCommand(cmd, ...args);
-        this.startNewCommandTimeout(cmd);
+        this.startNewCommandTimeout();
         return result;
       } else {
         logger.debug(`Executing Flutter driver command '${cmd}'`);

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -33,7 +33,7 @@ const WEBVIEW_NO_PROXY = [
   [`POST`, new RegExp(`^/session/[^/]+/touch/perform`)],
 ] as import('@appium/types').RouteMatcher[];
 
-class FlutterDriver extends BaseDriver {
+class FlutterDriver extends BaseDriver<any> {
   public socket: IsolateSocket | null = null;
   public locatorStrategies = [`key`, `css selector`];
   public proxydriver: any;


### PR DESCRIPTION
https://github.com/appium/appium/blob/fa0e853bd00bfcf7a9e6240bef2980d5566813c1/packages/base-driver/lib/basedriver/driver.js#L182

Maybe the original implementation in this repo was wrong, or changed.