### PR TITLE
feat: launch app via instrument service for ios only with appium flutter driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,12 @@ You have a couple of methods to start the application under test with establishi
     4. (at the same time) Launch the application under test via outside the appium-flutter-driver
         - e.g. Launch an iOS process via [ios-go](https://github.com/danielpaulus/go-ios), [iproxy](https://github.com/libimobiledevice/libusbmuxd#iproxy) or [tidevice](https://github.com/alibaba/taobao-iphone-device)
     5. Once `flutter:connectObservatoryWsUrl` identify the observatory URL, the command will establish a connection to the Dart VM
-
+4. Launch app with `flutter:launchApp'` for iOS
+    1. Start a session without `app` capability
+    2. Install the application under test via `driver.install_app` or `mobile:installApp` command etc
+    3. Calls `flutter:launchApp` command to start an iOS app via instrument service
+        - `driver.execute_script 'flutter:launchApp', 'com.example.bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` is example usage
+        - This launching method is the same as the above 3rd party method, but does the same thing only via the appium flutter driver.
 
 ## Changelog
 
@@ -256,8 +261,7 @@ Please replace them properly with your client.
 | - | :ok: | `getClipboard` | Appium |
 | - | :ok: | `setClipboard` | Appium |
 | - | :ok: | `connectObservatoryWsUrl` | Flutter Driver |
-
-
+| - | :ok: | `launchApp`, `driver.execute_script 'flutter:launchApp', 'bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` | Flutter Driver |
 
 ## Change the flutter engine attache to
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This snippet, taken from [example dir](https://github.com/appium-userland/appium
 - `scrollUntilTapable` command : An expectation for checking an element is visible and enabled such that you can click it. Using waitTapable to wait element
 - `driver.activateApp(appId)` starts the given app and attaches to the observatory URL in the `FLUTTER` context. The method may raise an exception if no observaotry URL was found. The typical case is the `appId` is already running. Then, the driver will fail to find the observatory URL.
 - `getClipboard` and `setClipboard` depend on each `NATIVE_APP` context behavior
-- Launch via 3rd party tool and attach for an iOS real device (debug/profile build)
+- Launch via `flutter:launchApp` or 3rd party tool (via instrument service) and attach to the Dart VM for an iOS real device (profile build)
     1. Do not set `app` nor `bundleId` to start a session without launching apps
     2. Start the app process via 3rd party tools such as [go-ios](https://github.com/danielpaulus/go-ios) to start the app process with debug mode in the middle of the new session process in 1) the above.
           - Then, the appium flutter session establish the WebSocket and proceed the session
@@ -164,7 +164,7 @@ You have a couple of methods to start the application under test with establishi
     4. (at the same time) Launch the application under test via outside the appium-flutter-driver
         - e.g. Launch an iOS process via [ios-go](https://github.com/danielpaulus/go-ios), [iproxy](https://github.com/libimobiledevice/libusbmuxd#iproxy) or [tidevice](https://github.com/alibaba/taobao-iphone-device)
     5. Once `flutter:connectObservatoryWsUrl` identify the observatory URL, the command will establish a connection to the Dart VM
-4. Launch app with `flutter:launchApp'` for iOS
+4. Launch app with `flutter:launchApp'` for iOS and attach to the Dart VM
     1. Start a session without `app` capability
     2. Install the application under test via `driver.install_app` or `mobile:installApp` command etc
     3. Calls `flutter:launchApp` command to start an iOS app via instrument service

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Please replace them properly with your client.
 | - | :ok: | `connectObservatoryWsUrl` | Flutter Driver |
 | - | :ok: | `launchApp`, `driver.execute_script 'flutter:launchApp', 'bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` | Flutter Driver |
 
+
+> **NOTE**
+> `flutter:launchApp` launches an app via instrument service. `mobile:activateApp` and `driver.activate_app` are via XCTest API. They are a bit different.
+
 ## Change the flutter engine attache to
 
 1. Get available isolate ids

--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## not released yet
+- Add `flutter:launchApp` to start an app via instrument service natively for iOS
+
 ## 1.18.1
 - Keep using XCUITest driver v4.27.0 for iOS versions lower than 15.
 

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -2,6 +2,7 @@ import { FlutterDriver } from '../driver';
 import { reConnectFlutterDriver } from '../sessions/session';
 import { longTap, scroll, scrollIntoView, scrollUntilVisible, scrollUntilTapable } from './execute/scroll';
 import { waitFor, waitForAbsent, waitForTappable } from './execute/wait';
+import { launchApp } from './../ios/app';
 
 
 const flutterCommandRegex = /^[\s]*flutter[\s]*:(.+)/;
@@ -19,6 +20,8 @@ export const execute = async function(
 
   const command = matching[1].trim();
   switch (command) {
+    case `launchApp`:
+      return flutterLaunchApp(this, args[0], args[1]);
     case `connectObservatoryWsUrl`:
       return connectObservatoryWsUrl(this);
     case `getVMInfo`:
@@ -81,6 +84,14 @@ export const execute = async function(
       throw new Error(`Command not support: "${rawCommand}"`);
   }
 };
+
+const flutterLaunchApp = async (
+  self: FlutterDriver, appId: string, opts
+) => {
+  const { arguments: args = [], environment: env = {}} = opts;
+  await launchApp(self.internalCaps.udid, appId, args, env);
+  await reConnectFlutterDriver.bind(self)(self.internalCaps);
+}
 
 const connectObservatoryWsUrl = async (self: FlutterDriver) => {
   await reConnectFlutterDriver.bind(self)(self.internalCaps);

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -17,6 +17,7 @@ import { execute } from './commands/execute';
 import { click, longTap, performTouch, tap, tapEl } from './commands/gesture';
 import { getScreenshot } from './commands/screen';
 import { getClipboard, setClipboard } from './commands/clipboard';
+import { launchApp } from './ios/app';
 
 // Need to not proxy in WebView context
 const WEBVIEW_NO_PROXY = [

--- a/driver/lib/ios/app.ts
+++ b/driver/lib/ios/app.ts
@@ -12,7 +12,7 @@ export const launchApp = async (udid, bundleId, args = [], env = {}) => {
   let instrumentService;
   try {
     instrumentService = await services.startInstrumentService(udid);
-    log.info(`${udid} Launching app ${bundleId} with arguments ${JSON.stringify(args)} and env ${JSON.stringify(env)}`);
+    log.info(`Launching app ${bundleId} with arguments ${JSON.stringify(args)} and env ${JSON.stringify(env)} on device ${udid}`);
     await instrumentService.callChannel(
       INSTRUMENT_CHANNEL.PROCESS_CONTROL,
       'launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:',

--- a/driver/lib/ios/app.ts
+++ b/driver/lib/ios/app.ts
@@ -1,0 +1,34 @@
+import {services, INSTRUMENT_CHANNEL} from 'appium-ios-device';
+import { log } from './../logger';
+
+/**
+ * Launch the given bundle id via instrument service.
+ *
+ * @param udid
+ * @param bundleId
+ * @returns
+ */
+export const launchApp = async (udid, bundleId, args = [], env = {}) => {
+  let instrumentService;
+  try {
+    instrumentService = await services.startInstrumentService(udid);
+    log.info(`${udid} Launching app ${bundleId} with arguments ${JSON.stringify(args)} and env ${JSON.stringify(env)}`);
+    await instrumentService.callChannel(
+      INSTRUMENT_CHANNEL.PROCESS_CONTROL,
+      'launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:',
+      '',
+      bundleId,
+      env,
+      args,
+      {'StartSuspendedKey': 0, 'KillExisting': 1}
+    );
+    return true;
+  } catch (err) {
+    log.warn(`Failed to launch '${bundleId}'. Original error: ${err.stderr || err.message}`);
+    return false;
+  } finally {
+    if (instrumentService) {
+      instrumentService.close();
+    }
+  }
+}


### PR DESCRIPTION
Launch the app via the instrument service natively for ios as `flutter:launchApp`.

`mobile:activateApp`  are via XCUITest, so via XCTest API. it is a bit different method