### PR TITLE
feat: Properly handle port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This snippet, taken from [example dir](https://github.com/appium-userland/appium
 | appium:maxRetryCount    | The count for socket connection retry for get flutter session (default 30)          | 20|
 | appium:observatoryWsUri | The URL to attach to the Dart VM. The appium flutter driver finds the WebSocket URL from the device log by default. You can skip the finding the URL process by specifying this capability. Then, this driver attempt to establish a WebSocket connection against the given WebSocket URL. Note that this capability expects the URL is ready for access by outside an appium session. This flutter driver does not do port-forwarding with this capability. You may need to coordinate the port-forwarding as well. | 'ws://127.0.0.1:60992/aaaaaaaaaaa=/ws' |
 | appium:skipPortForward | Whether skip port forwarding from the flutter driver local to the device under test with `observatoryWsUri` capability. It helps you to manage the application under test, the observatory URL and the port forwarding configuration. The default is `true`. | true, false |
+| appium:remoteAdbHost | The IP/hostname of the remote host ADB is running on. This capability only makes sense for Android platform. Providing it will implicitly override the host for the Observatory URL if the latter is determined from device logs. localhost be default | 192.168.1.20
+| appium:adbPort | The port number ADB server is running on. This capability only makes sense for Android platform. 5037 by default | 9999
+| appium:forwardingPort | The port number that will be used to forward the traffic from the device under test to locahost. Only applicable if `skipPortForward` is falsy. Not applicable if the test is executed on iOS Simulator. By default, it is the same as in the provided or autodetected Observatory URL. | 9999
 
 ### Context
 

--- a/driver/lib/desired-caps.ts
+++ b/driver/lib/desired-caps.ts
@@ -21,6 +21,9 @@ export interface IDesiredCapConstraints {
   skipPortForward: {
     isBoolean: boolean;
   };
+  adbPort: any;
+  remoteAdbHost: any;
+  forwardingPort: any;
 }
 
 export const desiredCapConstraints: IDesiredCapConstraints = {
@@ -57,5 +60,14 @@ export const desiredCapConstraints: IDesiredCapConstraints = {
   },
   skipPortForward: {
     isBoolean: true
-  }
+  },
+  adbPort: {
+    isNumber: true
+  },
+  remoteAdbHost: {
+    isString: true
+  },
+  forwardingPort: {
+    isNumber: true
+  },
 };

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -54,8 +54,8 @@ export const getObservatoryWsUri = async (proxydriver , caps) => {
   const remotePort = urlObject.port;
   const localPort = caps.forwardingPort ?? remotePort;
   urlObject.port = localPort;
-  log.debug(`Forwarding remote port ${urlObject.port} to the local port ${localPort}`);
-  await proxydriver.adb.forwardPort(urlObject.port, localPort);
+  log.debug(`Forwarding remote port ${remotePort} to the local port ${localPort}`);
+  await proxydriver.adb.forwardPort(remotePort, localPort);
   if (!caps.observatoryWsUri && proxydriver.adb.adbHost) {
     urlObject.host = proxydriver.adb.adbHost;
   }

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -54,7 +54,6 @@ export const getObservatoryWsUri = async (proxydriver , caps) => {
   const remotePort = urlObject.port;
   const localPort = caps.forwardingPort ?? remotePort;
   urlObject.port = localPort;
-  log.debug(`Forwarding remote port ${remotePort} to the local port ${localPort}`);
   await proxydriver.adb.forwardPort(localPort, remotePort);
   if (!caps.observatoryWsUri && proxydriver.adb.adbHost) {
     urlObject.host = proxydriver.adb.adbHost;

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -55,7 +55,7 @@ export const getObservatoryWsUri = async (proxydriver , caps) => {
   const localPort = caps.forwardingPort ?? remotePort;
   urlObject.port = localPort;
   log.debug(`Forwarding remote port ${remotePort} to the local port ${localPort}`);
-  await proxydriver.adb.forwardPort(remotePort, localPort);
+  await proxydriver.adb.forwardPort(localPort, remotePort);
   if (!caps.observatoryWsUri && proxydriver.adb.adbHost) {
     urlObject.host = proxydriver.adb.adbHost;
   }

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -140,7 +140,7 @@ export const getObservatoryWsUri = async (proxydriver, caps) => {
   try {
     await listeningPromise;
   } catch (e) {
-    throw new Error(`Cannot listen on the local port ${localPort}. Original error: ${e}`);
+    throw new Error(`Cannot listen on the local port ${localPort}. Original error: ${e.message}`);
   }
 
   log.info(`Forwarding the remote port ${remotePort} to the local port ${localPort}`);

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -53,8 +53,6 @@ export const connectSocket = async (
 
     if (!urlFetchError) {
       const connectedPromise = new Promise<IsolateSocket | null>((resolve) => {
-        log.info(`Connecting to Dart Observatory: ${dartObservatoryURL}`);
-
         const socket = new IsolateSocket(dartObservatoryURL);
 
         const removeListenerAndResolve = (r: IsolateSocket | null) => {
@@ -92,7 +90,7 @@ export const connectSocket = async (
               log.errorAndThrow(JSON.stringify(e));
             }
           };
-          log.info(`Connecting to ${dartObservatoryURL}`);
+          log.info(`Connecting to Dart Observatory: ${dartObservatoryURL}`);
           const vm = await socket.call(`getVM`) as {
             isolates: [{
               name: string,

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -193,8 +193,8 @@ export const executeElementCommand = async function(
 export const processLogToGetobservatory = (deviceLogs: [{ message: string }]) => {
   let dartObservatoryURL: URL|undefined;
   for (const line of deviceLogs.map((e) => e.message).reverse()) {
-    let match: RegExpMatchArray|null;
-    if ((match = line.match(OBSERVATORY_URL_PATTERN))) {
+    const match = line.match(OBSERVATORY_URL_PATTERN);
+    if (match) {
       dartObservatoryURL = new URL(match[2]);
       break;
     }

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -13,10 +13,10 @@ export const reConnectFlutterDriver = async function(this: FlutterDriver, caps: 
   const appPlatform = caps.platformName.toLowerCase();
   switch (appPlatform) {
     case `ios`:
-      [this.socket] = await connectIOSSession(this.proxydriver, caps)
+      this.socket = await connectIOSSession(this.proxydriver, caps);
       break;
     case `android`:
-      [this.socket] = await connectAndroidSession(this.proxydriver, caps)
+      this.socket = await connectAndroidSession(this.proxydriver, caps);
       break;
     default:
       log.errorAndThrow(


### PR DESCRIPTION
The driver was not working properly if remoteAdbHost and adbPort capabilities are provided. this has been fixed.
Also, added the new `forwardingPort` capability, which allows to customize the local port number used to forward traffic to the device under test. Previously this port was the same as the remote one, which might create unexpected conflicts if it was already occupied on the server host.

cc @KazuCocoa 