### PR TITLE
ci: use v3

### DIFF
--- a/.github/workflows/finder-node.js.yml
+++ b/.github/workflows/finder-node.js.yml
@@ -36,7 +36,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/finder-python.yml
+++ b/.github/workflows/finder-python.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
> [build (18)](https://github.com/appium-userland/appium-flutter-driver/actions/runs/5842567363/job/15843810479)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/