### PR TITLE
refactor: replace deprecated errorAndThrow with errorWithException in session and observatory modules

### DIFF
--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -65,7 +65,7 @@ export async function connectSocket(
           // `await` is needed so that rejected promise will be thrown and caught
           return await originalSocketCall.apply(socket, args);
         } catch (e) {
-          this.log.errorAndThrow(JSON.stringify(e));
+          this.log.errorWithException(new Error(JSON.stringify(e)));
         }
       };
       this.log.info(`Connecting to Dart Observatory: ${dartObservatoryURL}`);

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -12,7 +12,7 @@ import { PLATFORM } from '../platform';
 export const reConnectFlutterDriver = async function(this: FlutterDriver, caps: Record<string, any>) {
   // setup proxies - if platformName is not empty, make it less case sensitive
   if (!caps.platformName) {
-    this.log.errorAndThrow(`No platformName was given`);
+    this.log.errorWithException(new Error(`No platformName was given`));
   }
 
   switch (_.toLower(caps.platformName)) {
@@ -23,9 +23,11 @@ export const reConnectFlutterDriver = async function(this: FlutterDriver, caps: 
       this.socket = await connectAndroidSession.bind(this)(this.proxydriver, caps, true);
       break;
     default:
-      this.log.errorAndThrow(
-        `Unsupported platformName: ${caps.platformName}. ` +
-        `Only the following platforms are supported: ${_.keys(PLATFORM)}`
+      this.log.errorWithException(
+        new Error(
+          `Unsupported platformName: ${caps.platformName}. ` +
+          `Only the following platforms are supported: ${_.keys(PLATFORM)}`
+        )
       );
   }
 };
@@ -48,9 +50,11 @@ export const createSession: any = async function(this: FlutterDriver, sessionId:
         this.proxydriver.allowInsecure = this.allowInsecure;
         break;
       default:
-        this.log.errorAndThrow(
-          `Unsupported platformName: ${caps.platformName}. ` +
-          `Only the following platforms are supported: ${_.keys(PLATFORM)}`
+        this.log.errorWithException(
+          new Error(
+            `Unsupported platformName: ${caps.platformName}. ` +
+            `Only the following platforms are supported: ${_.keys(PLATFORM)}`
+          )
         );
     }
 


### PR DESCRIPTION
## Refactor: Replace deprecated `errorAndThrow` with `errorWithException`

This PR updates the codebase to replace all usages of the deprecated `errorAndThrow` method with the recommended `errorWithException` method. Error messages are now wrapped in a new `Error` object for improved error handling and stack traces.

**Details:**
- Updated `driver/lib/sessions/session.ts` and `driver/lib/sessions/observatory.ts` to use `this.log.errorWithException(new Error(...))` instead of `this.log.errorAndThrow(...)`.
- No functional changes; this is a refactor to align with current logging and error-handling best practices.

**Motivation:**
- Removes usage of deprecated methods.
- Ensures better error stack traces and future compatibility.