### PR TITLE
Supports any custom command extension directly

### DIFF
--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -162,6 +162,11 @@ const commandHandlers: CommandMap = {
       command: 'getTextWithCommandExtension',
       findBy: params.findBy,
     }),
+  customCommandExtension: async (driver, params) =>
+    await driver.socket.executeSocketCommand({
+      command: params.command,
+      ...params.args,
+    }),
 };
 export const execute = async function (
   this: FlutterDriver,


### PR DESCRIPTION
Call any custom command extension directly without adding new commands like 'getTextWithCommandExtension' 'dragAndDropWithCommandExtension'.

Once introduce a new extension in Flutter App like 'lib/drag_commands.dart' , it can be invoked from appium client immediately without any change to appium-flutter-driver.

example:
```ruby
payload = {
  startX: 100,
  startY: 100,
  endX: 100,
  endY: 600",
  duration: 15000
}

driver.execute_script 'flutter:customCommandExtension', {command: 'dragAndDropWithCommandExtension', args: payload}

# equals to 
# driver.execute_script("flutter:dragAndDropWithCommandExtension", payload)

```