### PR TITLE
fix: max retries and retry backoff check

### DIFF
--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -111,10 +111,16 @@ export async function getObservatoryWsUri (
         `Have you disabled it in capabilities?`
       );
     }
-    const lastMatch = await this._logmon.waitForLastMatchExist(
-      caps.maxRetryCount,
-      caps.retryBackoffTime
-    );
+
+    let lastMatch = null;
+    try {
+      lastMatch = await this._logmon.waitForLastMatchExist(
+        caps.maxRetryCount,
+        caps.retryBackoffTime
+      );
+    } catch (e) {
+      this.log.error(e);
+    }
     if (!lastMatch) {
       throw new Error(
         `No observatory URL matching to '${OBSERVATORY_URL_PATTERN}' was found in the device log. ` +

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -112,7 +112,7 @@ export async function getObservatoryWsUri (
       );
     }
 
-    let lastMatch = null;
+    let lastMatch : LogEntry | null = null;
     try {
       lastMatch = await this._logmon.waitForLastMatchExist(
         caps.maxRetryCount,

--- a/driver/lib/sessions/log-monitor.ts
+++ b/driver/lib/sessions/log-monitor.ts
@@ -21,6 +21,7 @@ export class LogMonitor {
     this._logsEmitter = logsEmitter;
     this._outputListener = null;
     this._filter = filter;
+    this._lastMatch = null;
   }
 
   get started(): boolean {


### PR DESCRIPTION
The initial value for logMatch will be undefined, because of which it will always return lastMatch and doesn't throw error. Because of which the retry doesn't occur.