### PR TITLE
chore(finder): remove obsolete @types/expect

### DIFF
--- a/finder/nodejs/package.json
+++ b/finder/nodejs/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^3.0.0",
     "@appium/tsconfig": "^1.0.0",
-    "@types/expect": "^24.3.0",
     "@types/mocha": "10.0.10",
     "@types/node": "^26.0.0",
     "expect": "^30.0.0",


### PR DESCRIPTION
## Summary

- Remove the deprecated `@types/expect` development dependency from `finder/nodejs`.
- `expect@^30.0.0` ships its own TypeScript declarations.

## Testing

- `npm run compile`
- `npm test`

## References

- [`@types/expect` on npm](https://www.npmjs.com/package/@types/expect/v/24.3.0) — deprecated stub package; `expect` provides its own types.
- [`expect` v30 package manifest](https://github.com/jestjs/jest/blob/v30.0.0/packages/expect/package.json) — declares its bundled TypeScript definitions.