### PR TITLE
Select isolate exposing ext.flutter.driver during connection

### DIFF
--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -91,9 +91,7 @@ export async function connectSocket(
               !Array.isArray(isolate.extensionRPCs) ||
               !isolate.extensionRPCs.includes(`ext.flutter.driver`)
             ) {
-              throw new Error(
-                `"ext.flutter.driver" is not available in isolate ${isolateId}`,
-              );
+              throw new Error(`"ext.flutter.driver" is not available in isolate ${isolateId}`);
             }
 
             socket.isolateId = isolateId;

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -75,56 +75,80 @@ export async function connectSocket(
       };
       this.log.info(`Connecting to Dart Observatory: ${dartObservatoryURL}`);
 
-      if (isolateId) {
-        this.log.info(`Listing the given isolate id: ${isolateId}`);
-        socket.isolateId = isolateId;
-      } else {
-        const vm = (await socket.call(`getVM`)) as {
-          isolates: [
-            {
-              name: string;
-              id: number;
-            },
-          ];
-        };
-        this.log.info(`Listing all isolates: ${JSON.stringify(vm.isolates)}`);
-        // To accept 'main.dart:main()' and 'main'
-        const mainIsolateData = vm.isolates.find((e) => e.name.includes(`main`));
-        if (!mainIsolateData) {
-          this.log.error(`Cannot get Dart main isolate info`);
-          removeListenerAndResolve(null);
-          socket.close();
-          return;
-        }
-        // e.g. 'isolates/2978358234363215', '2978358234363215'
-        socket.isolateId = mainIsolateData.id;
-      }
-
-      // It could take time to load the expected module.
       try {
         await retryInterval(moduleCheckIntervalCount, moduleCheckIntervalMs, async () => {
-          const isolate = (await socket.call(`getIsolate`, {
-            isolateId: `${socket.isolateId}`,
-          })) as {
-            extensionRPCs: [string] | null;
+          if (isolateId) {
+            this.log.info(`Checking the given isolate id: ${isolateId}`);
+
+            const isolate = (await socket.call(`getIsolate`, {
+              isolateId: `${isolateId}`,
+            })) as {
+              extensionRPCs: string[] | null;
+            } | null;
+
+            if (
+              !isolate ||
+              !Array.isArray(isolate.extensionRPCs) ||
+              !isolate.extensionRPCs.includes(`ext.flutter.driver`)
+            ) {
+              throw new Error(
+                `"ext.flutter.driver" is not available in isolate ${isolateId}`,
+              );
+            }
+
+            socket.isolateId = isolateId;
+            return;
+          }
+
+          // Refresh the isolate list on every retry because a background
+          // engine may start before the UI engine.
+          const vm = (await socket.call(`getVM`)) as {
+            isolates: Array<{
+              name: string;
+              id: string | number;
+              isolateGroupId?: string;
+            }>;
           } | null;
-          if (!isolate) {
-            throw new Error(`Cannot get main Dart Isolate`);
+
+          if (!vm || !Array.isArray(vm.isolates)) {
+            throw new Error(`Cannot get Dart VM isolate list`);
           }
-          if (!Array.isArray(isolate.extensionRPCs)) {
-            throw new Error(`Cannot get Dart extensionRPCs from isolate ${JSON.stringify(isolate)}`);
+
+          this.log.info(`Listing all isolates: ${JSON.stringify(vm.isolates)}`);
+
+          for (const candidate of vm.isolates) {
+            const isolate = (await socket.call(`getIsolate`, {
+              isolateId: `${candidate.id}`,
+            })) as {
+              extensionRPCs: string[] | null;
+            } | null;
+
+            if (
+              isolate &&
+              Array.isArray(isolate.extensionRPCs) &&
+              isolate.extensionRPCs.includes(`ext.flutter.driver`)
+            ) {
+              socket.isolateId = candidate.id;
+
+              this.log.info(
+                `Selected Flutter driver isolate: ${candidate.id} ` +
+                  `(${candidate.name}, group ${candidate.isolateGroupId ?? `unknown`})`,
+              );
+
+              return;
+            }
           }
-          if (isolate.extensionRPCs.indexOf(`ext.flutter.driver`) < 0) {
-            throw new Error(
-              `"ext.flutter.driver" is not found in "extensionRPCs" ${JSON.stringify(isolate.extensionRPCs)}`,
-            );
-          }
+
+          throw new Error(`"ext.flutter.driver" was not found in any Dart isolate`);
         });
       } catch (e) {
-        this.log.error(e.message);
+        const message = e instanceof Error ? e.message : String(e);
+        this.log.error(message);
         removeListenerAndResolve(null);
+        socket.close();
         return;
       }
+
       removeListenerAndResolve(socket);
     };
     socket.on(`open`, onOpenListener);


### PR DESCRIPTION
## Problem

On Android, a data-only FCM message can start a headless Flutter engine to run a `firebase_messaging` background handler before the application's UI engine starts.

This can result in two root isolates named `main`:

- A background isolate that does not expose `ext.flutter.driver`.
- A UI isolate that exposes `ext.flutter.driver`.

During automatic discovery, `connectSocket` currently selects the first isolate whose name contains `main` and polls only that isolate.

If the background isolate appears first, connection fails with:

```text
"ext.flutter.driver" is not found in "extensionRPCs"
Cannot connect to the Dart Observatory URL
```

This is related to the two-`main`-isolate behavior reported in #756.

## Fix

For automatic isolate discovery, this change:

1. Refreshes the VM isolate list on each retry.
2. Inspects the available isolates using `getIsolate`.
3. Selects an isolate only when its `extensionRPCs` contains `ext.flutter.driver`.
4. Continues polling with a refreshed isolate list if the UI isolate has not registered the extension yet.
5. Preserves explicit `appium:isolateId` behavior by validating only the configured isolate.

## Manual verification

I verified the change with an Android terminated-app notification flow:

1. A data-only FCM message started a background Flutter engine.
2. Tapping the notification started the UI Flutter engine.
3. The Dart VM reported two isolates named `main`.
4. The updated logic selected the isolate exposing `ext.flutter.driver`.
5. `flutter:connectObservatoryWsUrl` succeeded.
6. Existing Flutter ValueKey finders and interactions succeeded.

## Validation

- `npm run build`
- `npm run lint`
- `npm run format:check`
- Existing Android and iOS GitHub Actions checks